### PR TITLE
Moved Bundler from runtime to development dependencies

### DIFF
--- a/tire-contrib.gemspec
+++ b/tire-contrib.gemspec
@@ -13,9 +13,9 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "tire-contrib"
 
-  s.add_dependency "bundler", "~> 1.0.0"
   s.add_dependency "tire"
 
+  s.add_development_dependency "bundler", "~> 1.0.0"
   s.add_development_dependency "turn"
   s.add_development_dependency "shoulda"
   s.add_development_dependency "mocha"


### PR DESCRIPTION
Hi,

I moved Bundler from the runtime dependencies to the development dependencies. I'm testing Bundler 1.1rc and I can't use tire-contrib with it, because it depends of bundler ~>1.0.0.
