### PR TITLE
More_like_this support

### DIFF
--- a/lib/tire/more_like_this.rb
+++ b/lib/tire/more_like_this.rb
@@ -1,0 +1,36 @@
+# More Like This
+# ============
+#
+# Author: Mereghost <marcello.rocha@gmail.com>
+#
+#
+# Adds support for more like this queries for Tire.
+#
+# It hooks into the Query class and inserts the more_like_this and more_like_this_field query types.
+#
+# Usage:
+# ------
+#
+# Require the component:
+#
+#     require 'tire/more_like_this'
+#
+# From that point on you should have the more_like_this (aliased to mlt) and
+# the more_like_this_field (aliased to mlt_field) queries available.
+#
+# Example:
+#   tire.search 'articles' do
+#     query do
+#        more_like_this 'search for similar text'
+#        more_like_this_field :field_name, 'similar text'
+#     end
+#   end
+#
+#  For available options for these queries see the relevant ES documentations
+#
+
+require 'tire/more_like_this/more_like_this'
+
+Tire::Search::Query.class_eval do
+  include Tire::Search::MoreLikeThis
+end

--- a/lib/tire/more_like_this/more_like_this.rb
+++ b/lib/tire/more_like_this/more_like_this.rb
@@ -1,0 +1,30 @@
+module Tire
+  module Search
+    module MoreLikeThis
+      def more_like_this(like_text, options = {})
+        @value = {:mlt => {:like_text => like_text}}
+        @value[:mlt].update(validate_more_like_this_options(options))
+        @value
+      end
+
+      def more_like_this_field(field, like_text, options = {})
+        @value = {:mlt_field => {field => {:like_text => like_text}}}
+        # :fields is invalid in this context. Better than doing some kind of meta-black magic.
+        options.delete(:fields)
+        @value[:mlt_field][field].update(validate_more_like_this_options(options))
+        @value
+      end
+
+      alias_method :mlt, :more_like_this
+      alias_method :mlt_field, :more_like_this_field
+
+      private
+      def validate_more_like_this_options(options)
+        valid_options = [:fields, :percent_terms_to_match, :min_term_freq,
+                         :max_query_terms, :stop_words, :min_doc_freq, :max_doc_freq,
+                         :min_word_len, :max_word_len, :boost_terms, :boost, :analyzer]
+        options.delete_if { |key, value| !valid_options.member? key }
+      end
+    end
+  end
+end

--- a/test/more_like_this/more_like_this_test.rb
+++ b/test/more_like_this/more_like_this_test.rb
@@ -1,0 +1,37 @@
+require 'tire'
+require 'tire/more_like_this'
+require 'shoulda'
+
+module Tire
+  module Search
+    class MoreLikeThisTest < Test::Unit::TestCase
+      context "More Like This queries" do
+        should "search for similar documents" do
+          assert_equal({:mlt => {:like_text => 'similar text'}}, Query.new.mlt('similar text'))
+        end
+
+        should "allow to pass a list of fields to a mlt query" do
+          assert_equal({:mlt => {:like_text => 'similar text', :fields => ['foo', 'bar.baz']}},
+                       Query.new.mlt('similar text', :fields => ['foo', 'bar.baz']))
+          assert_equal({:mlt => {:like_text => 'similar text', :fields => ['foo', 'bar.baz'], :min_term_freq => 3}},
+                       Query.new.mlt('similar text', :fields => ['foo', 'bar.baz'], :min_term_freq => 3))
+        end
+
+        should "search for similar text on a selected field (mlt_field)" do
+          assert_equal({:mlt_field => {:foo => {:like_text => 'similar text'}}},
+                       Query.new.mlt_field(:foo, 'similar text'))
+          assert_equal({:mlt_field => {:foo => {:like_text => 'similar text', :min_term_freq => 1}}},
+                       Query.new.mlt_field(:foo, 'similar text', :min_term_freq => 1))
+        end
+      end
+      context "validate the options passed" do
+        should "drop all the invalid keys" do
+          assert_equal({:mlt => {:like_text => 'similar text', :fields => ['foo', 'bar.baz']}},
+                       Query.new.mlt('similar text', :fields => ['foo', 'bar.baz'], :foo => :bar))
+          assert_equal({:mlt_field => {:foo => {:like_text => 'similar text'}}},
+                       Query.new.mlt_field(:foo, 'similar text', :fields => [:bar]))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds two new methods: more_like_this and more_like_this_field to the query capabilities of tire.
