### PR TITLE
Deprecations

### DIFF
--- a/lib/tire/rails-logger.rb
+++ b/lib/tire/rails-logger.rb
@@ -21,7 +21,7 @@
 #     Started GET "/articles?utf8=%E2%9C%93&q=bull*&commit=search" for 127.0.0.1 at 2011-09-15 19:07:00 +0200
 #       Processing by ArticlesController#index as HTML
 #       Parameters: {"utf8"=>"✓", "q"=>"bull*", "commit"=>"search"}
-#       Tire search (6.7ms)  {"query":{"query_string":{"query":"bull*"}}}
+#       Search (6.7ms)  {"query":{"query_string":{"query":"bull*"}}}
 #       Article Load (0.3ms)  SELECT `articles`.* FROM `articles` WHERE `articles`.`id` IN (104126575)
 #     Rendered articles/index.html.erb within layouts/application (13.0ms)
 #     Completed 200 OK in 63ms (Views: 53.7ms | ActiveRecord: 1.8ms | Tire: 6.7ms)

--- a/lib/tire/rails-logger/instrumentation.rb
+++ b/lib/tire/rails-logger/instrumentation.rb
@@ -7,13 +7,11 @@ module Tire
         alias_method_chain :perform, :instrumentation
       end
 
-      module InstanceMethods
-        def perform_with_instrumentation
-          # Wrapper around the Search.perform method that logs search times.
-          #
-          ActiveSupport::Notifications.instrument("search.tire", :name => 'Search', :search => self.to_json) do
-            perform_without_instrumentation
-          end
+      def perform_with_instrumentation
+        # Wrapper around the Search.perform method that logs search times.
+        #
+        ActiveSupport::Notifications.instrument("search.tire", :name => 'Search', :search => self.to_json) do
+          perform_without_instrumentation
         end
       end
     end

--- a/test/rails-logger/log_subscriber_test.rb
+++ b/test/rails-logger/log_subscriber_test.rb
@@ -58,7 +58,7 @@ module Tire
           ActiveRecordArticle.search '*', :load => true
           wait
           assert_equal 1, @logger.logged(:debug).size
-          assert_match /Tire/, @logger.logged(:debug).last
+          assert_match /Search \(\d+\.?\d*ms\)/, @logger.logged(:debug).last
         end
 
       end

--- a/tire-contrib.gemspec
+++ b/tire-contrib.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "shoulda"
   s.add_development_dependency "mocha"
   s.add_development_dependency "sdoc"
-  s.add_development_dependency "rcov"
 
   s.extra_rdoc_files  = [ "README.markdown", "MIT-LICENSE" ]
   s.rdoc_options      = [ "--charset=UTF-8" ]


### PR DESCRIPTION
Changed a few things:
- InstanceMethods is deprecated in ActiveSupport::Concern
  (see https://github.com/rails/rails/commit/401393b6561adc1ce7101945163c9601257c057a)
- Fixed tests to match output (and fixed sample output)
- Remove rcov from gemspec which doesn't support Ruby 1.9 AFAIK (and isn't used anyway)
