### PR TITLE
relax bundler dependency

### DIFF
--- a/tire-contrib.gemspec
+++ b/tire-contrib.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "tire"
 
-  s.add_development_dependency "bundler", "~> 1.1.0"
+  s.add_development_dependency "bundler", "~> 1.1"
 
   s.add_development_dependency "newrelic_rpm"
 


### PR DESCRIPTION
so you can use it with bundler 1.1 and 1.2
