### PR TITLE
add Tire::Namespace

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -27,6 +27,10 @@ Adds support for [“custom filters score”](http://www.elasticsearch.org/guide
 
 Adds support for displaying Tire related statistics in the Rails' log.
 
+### Namespace ###
+
+Adds support for namespace all Index's of an Application
+
 -----
 
 [Karel Minarik](http://karmi.cz) and [contributors](http://github.com/karmi/tire-contrib/contributors)

--- a/lib/tire/namespace.rb
+++ b/lib/tire/namespace.rb
@@ -1,0 +1,12 @@
+require 'tire/namespace/index'
+require 'tire/namespace/configuration'
+
+module Tire
+  Index.class_eval do
+    include Tire::Namespace::Index
+  end
+
+  Configuration.class_eval do
+    extend Tire::Namespace::Configuration
+  end
+end

--- a/lib/tire/namespace/configuration.rb
+++ b/lib/tire/namespace/configuration.rb
@@ -1,0 +1,9 @@
+module Tire
+  module Namespace
+    module Configuration
+      def namespace(name = nil)
+        @namespace = name || @namespace
+      end
+    end
+  end
+end

--- a/lib/tire/namespace/index.rb
+++ b/lib/tire/namespace/index.rb
@@ -1,0 +1,15 @@
+module Tire
+  module Namespace
+    module Index
+      def self.included klass
+        klass.class_eval do
+          alias_method :original_name, :name
+
+          define_method :name do
+            Tire::Configuration.namespace ? "#{Tire::Configuration.namespace}-#{@name}" : @name
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/namespace/configuration_test.rb
+++ b/test/namespace/configuration_test.rb
@@ -1,0 +1,31 @@
+require 'tire'
+require 'tire/namespace'
+require 'shoulda'
+
+module Tire
+  module Namespace
+    class ConfigurationTest < Test::Unit::TestCase
+      context "Namespace" do
+        context "Configuration" do
+          def teardown
+            Tire::Configuration.reset
+          end
+
+          should "extend Tire::Configuration with 'namespace'" do
+            assert_nothing_raised { Tire::Configuration.namespace("foo") }
+          end
+
+          should "set namespace" do
+            Tire::Configuration.namespace("foo")
+            assert_equal "foo", Tire::Configuration.instance_variable_get(:@namespace)
+          end
+
+          should "get namespace" do
+            Tire::Configuration.instance_variable_set(:@namespace, "bar")
+            assert_equal "bar", Tire::Configuration.namespace
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/namespace/index_test.rb
+++ b/test/namespace/index_test.rb
@@ -1,0 +1,26 @@
+require 'tire'
+require 'tire/namespace'
+require 'shoulda'
+
+module Tire
+  module Namespace
+    class IndexTest < Test::Unit::TestCase
+      context "Namespace" do
+        context "index" do
+          def teardown
+            Tire::Configuration.reset
+          end
+
+          should "return the name with an namespace" do
+            Tire.configure { namespace "foo" }
+            assert_equal "foo-bar", Tire.index("bar").name
+          end
+
+          should "return the name without an namespace" do
+            assert_equal "bar", Tire.index("bar").name
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/namespace/index_test.rb
+++ b/test/namespace/index_test.rb
@@ -16,6 +16,14 @@ module Tire
             assert_equal "foo-bar", Tire.index("bar").name
           end
 
+          should "return the name with an namespace (with block)" do
+            Tire.configure { namespace "foo" }
+            index = Tire.index("xxx") do
+              @name = "bar"
+            end
+            assert_equal "foo-bar", index.name
+          end
+
           should "return the name without an namespace" do
             assert_equal "bar", Tire.index("bar").name
           end


### PR DESCRIPTION
you can namespace each Index

``` ruby
Tire.configure { namespace "foo" }
Tire.index("bar").name # => "foo-bar"
```
