### PR TITLE
Add support to :params for custom_filters_score

### DIFF
--- a/lib/tire/queries/custom_filters_score/custom_filters_score.rb
+++ b/lib/tire/queries/custom_filters_score/custom_filters_score.rb
@@ -64,6 +64,11 @@ module Tire
           @value
         end
 
+        def params(value)
+          @value[:params] = value
+          @value
+        end
+
         def to_hash
           @value[:filters] ? 
           @value : 

--- a/test/queries/custom_filters_score/custom_filters_score_test.rb
+++ b/test/queries/custom_filters_score/custom_filters_score_test.rb
@@ -95,10 +95,9 @@ module Tire
             params :a => 'b'
           end
 
-          query[:custom_filters_score].tap do |f|
-            assert_equal( { :term => { :foo => { :term => 'bar' } } }, f[:query].to_hash )
-            assert_equal( {:a => 'b'}, f[:params])
-          end
+          f = query[:custom_filters_score]
+          assert_equal( { :term => { :foo => { :term => 'bar' } } }, f[:query].to_hash )
+          assert_equal( { :a => 'b' }, f[:params] )
         end
 
       end

--- a/test/queries/custom_filters_score/custom_filters_score_test.rb
+++ b/test/queries/custom_filters_score/custom_filters_score_test.rb
@@ -89,6 +89,18 @@ module Tire
           end
         end
 
+        should "allow setting params" do
+          query = Query.new.custom_filters_score do
+            query { term :foo, 'bar' }
+            params :a => 'b'
+          end
+
+          query[:custom_filters_score].tap do |f|
+            assert_equal( { :term => { :foo => { :term => 'bar' } } }, f[:query].to_hash )
+            assert_equal( {:a => 'b'}, f[:params])
+          end
+        end
+
       end
     end
     


### PR DESCRIPTION
Just added support to use `params` with `custom_filters_score`. Params are often necessary when creating more complex score scripts. For example:

``` ruby
query do
  custom_filters_score do
    query { string 'volmer' }

    params now: Time.now.to_i * 1000

    filter do
      filter 'exists', field: 'created_at'
      script "((0.08 / ((3.16*pow(10,-11)) * abs(now - doc['created_at'].date.getMillis()) + 0.05)))"
    end
  end
end
```

Thanks to [@thor27](https://github.com/thor27) and [Jon Tai's blog post](http://jontai.me/blog/2013/01/advanced-scoring-in-elasticsearch/).
