### PR TITLE
remove "script" config from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ language: ruby
 rvm:
   - 1.9.3
 
-script: "bundle exec rake test"
-
 before_install:
   - sudo service elasticsearch start
 


### PR DESCRIPTION
thins `test` is the rake default task we don't longer need this
