### PR TITLE
Add more like this API call

### DIFF
--- a/lib/tire/queries/more_like_this.rb
+++ b/lib/tire/queries/more_like_this.rb
@@ -39,5 +39,5 @@
 require 'tire/queries/more_like_this/more_like_this'
 
 Tire::Search::Query.class_eval do
-  include Tire::Search::MoreLikeThis
+  include Tire::Search::MoreLikeThis::Query
 end

--- a/lib/tire/queries/more_like_this.rb
+++ b/lib/tire/queries/more_like_this.rb
@@ -41,3 +41,84 @@ require 'tire/queries/more_like_this/more_like_this'
 Tire::Search::Query.class_eval do
   include Tire::Search::MoreLikeThis::Query
 end
+
+module Tire::Model::Search::InstanceMethods
+  # Returns search results for a given query.
+  #
+  # Query can be passed simply as a String:
+  #
+  #     @article.more_like_this 'love'
+  #
+  # Any options, such as pagination or sorting, can be passed as a second argument:
+  #
+  #     @article.more_like_this 'love', :per_page => 25, :page => 2
+  #     @article.more_like_this 'love', :sort => 'title'
+  #
+  # For more powerful query definition, use the query DSL passed as a block:
+  #
+  #     @article.more_like_this do
+  #       query { terms :tags, ['ruby', 'python'] }
+  #       facet 'tags' { terms :tags }
+  #     end
+  #
+  # You can pass options as the first argument, in this case:
+  #
+  #     @article.more_like_this :per_page => 25, :page => 2 do
+  #       query { string 'love' }
+  #     end
+  #
+  # This methods returns a Tire::Results::Collection instance, containing instances
+  # of Tire::Results::Item, populated by the data available in _Elasticsearch, by default.
+  #
+  # If you'd like to load the "real" models from the database, you may use the `:load` option:
+  #
+  #     @article.more_like_this 'love', :load => true
+  #
+  # You can pass options as a Hash to the model's `find` method:
+  #
+  #     @article.more_like_this :load => { :include => 'comments' } do ... end
+  #
+  def more_like_this(*args, &block)
+    default_options = {:type => instance.class.tire.document_type, :index => instance.class.tire.index.name}
+
+    if block_given?
+      options = args.shift || {}
+    else
+      query, options = args
+      options ||= {}
+    end
+
+    options[:mlt_fields] = options[:mlt_fields].join(',') if options[:mlt_fields]
+    options   = default_options.update(options)
+    sort      = Array( options.delete(:order) || options.delete(:sort) )
+
+    s = Tire::Search::MoreLikeThis::Search.new(options.delete(:index), instance.id, options)
+
+    page     = options.delete(:page)
+    per_page = options.delete(:per_page) || Tire::Results::Pagination::default_per_page
+
+    s.size( per_page.to_i ) if per_page
+    s.from( page.to_i <= 1 ? 0 : (per_page.to_i * (page.to_i-1)) ) if page && per_page
+
+    s.sort do
+      sort.each do |t|
+        field_name, direction = t.split(':')
+        by field_name, direction
+      end
+    end unless sort.empty?
+
+    version = options.delete(:version)
+    s.version(version) if version
+
+    if block_given?
+      block.arity < 1 ? s.instance_eval(&block) : block.call(s)
+    else
+      s.query { string query }
+      # TODO: Actualy, allow passing all the valid options from
+      # <http://www.elasticsearch.org/guide/reference/api/search/uri-request.html>
+      s.fields Array(options[:fields]) if options[:fields]
+    end
+
+    s.results
+  end
+end

--- a/lib/tire/queries/more_like_this/more_like_this.rb
+++ b/lib/tire/queries/more_like_this/more_like_this.rb
@@ -1,29 +1,31 @@
 module Tire
   module Search
     module MoreLikeThis
-      def more_like_this(like_text, options = {})
-        @value = {:mlt => {:like_text => like_text}}
-        @value[:mlt].update(validate_more_like_this_options(options))
-        @value
-      end
+      module Query
+        def more_like_this(like_text, options = {})
+          @value = {:mlt => {:like_text => like_text}}
+          @value[:mlt].update(validate_more_like_this_options(options))
+          @value
+        end
 
-      def more_like_this_field(field, like_text, options = {})
-        @value = {:mlt_field => {field => {:like_text => like_text}}}
-        # :fields is invalid in this context. Better than doing some kind of meta-black magic.
-        options.delete(:fields)
-        @value[:mlt_field][field].update(validate_more_like_this_options(options))
-        @value
-      end
+        def more_like_this_field(field, like_text, options = {})
+          @value = {:mlt_field => {field => {:like_text => like_text}}}
+          # :fields is invalid in this context. Better than doing some kind of meta-black magic.
+          options.delete(:fields)
+          @value[:mlt_field][field].update(validate_more_like_this_options(options))
+          @value
+        end
 
-      alias_method :mlt, :more_like_this
-      alias_method :mlt_field, :more_like_this_field
+        alias_method :mlt, :more_like_this
+        alias_method :mlt_field, :more_like_this_field
 
-      private
-      def validate_more_like_this_options(options)
-        valid_options = [:fields, :percent_terms_to_match, :min_term_freq,
-                         :max_query_terms, :stop_words, :min_doc_freq, :max_doc_freq,
-                         :min_word_len, :max_word_len, :boost_terms, :boost, :analyzer]
-        options.delete_if { |key, value| !valid_options.member? key }
+        private
+        def validate_more_like_this_options(options)
+          valid_options = [:fields, :percent_terms_to_match, :min_term_freq,
+                           :max_query_terms, :stop_words, :min_doc_freq, :max_doc_freq,
+                           :min_word_len, :max_word_len, :boost_terms, :boost, :analyzer]
+          options.delete_if { |key, value| !valid_options.member? key }
+        end
       end
     end
   end

--- a/lib/tire/queries/more_like_this/more_like_this.rb
+++ b/lib/tire/queries/more_like_this/more_like_this.rb
@@ -27,6 +27,27 @@ module Tire
           options.delete_if { |key, value| !valid_options.member? key }
         end
       end
+
+      class Search < Tire::Search::Search
+
+        attr_reader :document_id
+
+        def initialize(indices=nil, document_id=nil, options={}, &block)
+          if indices.is_a?(Hash)
+            set_indices_options(indices)
+            @indices = indices.keys
+          else
+            @indices = Array(indices)
+          end
+          @types   = Array(options.delete(:type)).map { |type| Utils.escape(type) }
+          @options = options
+          @document_id = document_id
+
+          @path    = ['/', @indices.join(','), @types.join(','), @document_id, '_mlt'].compact.join('/').squeeze('/')
+
+          block.arity < 1 ? instance_eval(&block) : block.call(self) if block_given?
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This is more a proof of concept if and how to implement `_mlt`
http://www.elasticsearch.org/guide/reference/api/more-like-this/

This is how to call it currently

``` ruby
tire.more_like_this(page: params[:page], per_page: params[:per_page], mlt_fields: %w(title subtitle abstract series journal), min_term_freq: 1, min_doc_freq: 2) do
  query do
    all
  end

  Rails.logger.debug to_curl
end
```
- I don't like that I had to copy so much from other methods. Would love if I could solve this with even much less code
- There are no tests

I would love to hear feedback on this.
- Am I doing it right?
- What would you do differently?
- Is this useful in general?
