### PR TITLE
Wildcard query

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -27,6 +27,10 @@ Adds support for [“more like this”](http://www.elasticsearch.org/guide/refer
 
 Adds support for [“fuzzy like this”](http://www.elasticsearch.org/guide/reference/query-dsl/flt-query.html) queries.
 
+### Wildcard Queries ###
+
+Adds support for [“wildcard”](http://http://www.elasticsearch.org/guide/reference/query-dsl/wildcard-query/) queries.
+
 ### Custom Filters Score ###
 
 Adds support for [“custom filters score”](http://www.elasticsearch.org/guide/reference/query-dsl/custom-filters-score-query.html) queries.

--- a/README.markdown
+++ b/README.markdown
@@ -29,7 +29,7 @@ Adds support for [“fuzzy like this”](http://www.elasticsearch.org/guide/refe
 
 ### Wildcard Queries ###
 
-Adds support for [“wildcard”](http://http://www.elasticsearch.org/guide/reference/query-dsl/wildcard-query/) queries.
+Adds support for [“wildcard”](http://www.elasticsearch.org/guide/reference/query-dsl/wildcard-query/) queries.
 
 ### Custom Filters Score ###
 

--- a/lib/tire/queries/wildcard.rb
+++ b/lib/tire/queries/wildcard.rb
@@ -1,0 +1,46 @@
+# Wildcard
+# ==============
+#
+# Author: Curtis Hatter <mitchell.hatter@gmail.com>
+#
+#
+# Adds support for "wildcard" queries in Tire DSL.
+#
+# It hooks into the Query class and inserts the wildcard query type.
+#
+#
+# Usage:
+# ------
+#
+# Require the component:
+#
+#     require 'tire/queries/wildcard'
+#
+# From that point on you should have the wildcard query available.
+#
+#
+# Example:
+# -------
+#
+#     Tire.search 'articles' do
+#       query do
+#         wildcard :field_name, 'ki*y'
+#       end
+#     end
+#
+#     Tire.search 'articles' do
+#       query do
+#         wildcard :field_name, 'ki*y', boost: 2.0
+#       end
+#     end
+#
+# For more about this query:
+#
+# * <http://www.elasticsearch.org/guide/reference/query-dsl/wildcard-query/>
+#
+#
+require 'tire/queries/wildcard/wildcard'
+
+Tire::Search::Query.class_eval do
+  include Tire::Search::Wildcard
+end

--- a/lib/tire/queries/wildcard/wildcard.rb
+++ b/lib/tire/queries/wildcard/wildcard.rb
@@ -1,0 +1,17 @@
+module Tire
+  module Search
+    module Wildcard
+      def wildcard(field, text, options = {})
+        @value = {:wildcard => { field => { value: text } } }
+        @value[:wildcard][field].update(validate_wildcard_options(options))
+        @value
+      end
+
+      private
+      def validate_wildcard_options(options)
+        valid_options = [:boost]
+        options.delete_if { |key, value| !valid_options.member? key }
+      end
+    end
+  end
+end

--- a/lib/tire/queries/wildcard/wildcard.rb
+++ b/lib/tire/queries/wildcard/wildcard.rb
@@ -2,7 +2,7 @@ module Tire
   module Search
     module Wildcard
       def wildcard(field, text, options = {})
-        @value = {:wildcard => { field => { value: text } } }
+        @value = {:wildcard => { field => { :value => text } } }
         @value[:wildcard][field].update(validate_wildcard_options(options))
         @value
       end

--- a/test/queries/wildcard/wildcard_test.rb
+++ b/test/queries/wildcard/wildcard_test.rb
@@ -1,0 +1,30 @@
+require 'tire'
+require 'tire/queries/wildcard'
+require 'shoulda'
+
+module Tire
+  module Search
+    class WildcardTest < Test::Unit::TestCase
+      
+      context "Wildcard queries" do
+        should "search for documents that have fields matching a wildcard expression" do
+          assert_equal({:wildcard => {:user => { value: 'ki*y'}}}, Query.new.wildcard(:user, 'ki*y'))
+        end
+
+        should "allow to boost a wildcard query" do
+          assert_equal({:wildcard => {:user => { value: 'ki*y', :boost => 2.0}}},
+                       Query.new.wildcard(:user, 'ki*y', :boost => 2.0))
+        end
+      end
+      
+      context "validate the options passed" do
+        should "drop all the invalid keys" do
+          assert_equal({:wildcard => {:user => 'ki*y', :boost => 2.0}},
+                       Query.new.mlt(:user, 'ki*y', :boost => 2.0, :foo => :bar))
+          assert_equal({:wildcard => {:user => {:value => 'ki*y', :boost => 2.0}}},
+                       Query.new.mlt_field(:user, 'ki*y', :boost => 2.0, :fields => [:bar]))
+        end
+      end
+    end
+  end
+end

--- a/test/queries/wildcard/wildcard_test.rb
+++ b/test/queries/wildcard/wildcard_test.rb
@@ -8,21 +8,21 @@ module Tire
       
       context "Wildcard queries" do
         should "search for documents that have fields matching a wildcard expression" do
-          assert_equal({:wildcard => {:user => { value: 'ki*y'}}}, Query.new.wildcard(:user, 'ki*y'))
+          assert_equal({:wildcard => {:user => {:value => 'ki*y'}}}, Query.new.wildcard(:user, 'ki*y'))
         end
 
         should "allow to boost a wildcard query" do
-          assert_equal({:wildcard => {:user => { value: 'ki*y', :boost => 2.0}}},
+          assert_equal({:wildcard => {:user => {:value => 'ki*y', :boost => 2.0}}},
                        Query.new.wildcard(:user, 'ki*y', :boost => 2.0))
         end
       end
       
       context "validate the options passed" do
         should "drop all the invalid keys" do
-          assert_equal({:wildcard => {:user => 'ki*y', :boost => 2.0}},
-                       Query.new.mlt(:user, 'ki*y', :boost => 2.0, :foo => :bar))
           assert_equal({:wildcard => {:user => {:value => 'ki*y', :boost => 2.0}}},
-                       Query.new.mlt_field(:user, 'ki*y', :boost => 2.0, :fields => [:bar]))
+                       Query.new.wildcard(:user, 'ki*y', :boost => 2.0, :foo => :bar))
+          assert_equal({:wildcard => {:user => {:value => 'ki*y', :boost => 2.0}}},
+                       Query.new.wildcard(:user, 'ki*y', :boost => 2.0, :fields => [:bar]))
         end
       end
     end


### PR DESCRIPTION
Adds support for [“wildcard”](http://www.elasticsearch.org/guide/reference/query-dsl/wildcard-query/) query.
