### PR TITLE
Add support for dynamic templates in the mapping DSL

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -39,6 +39,10 @@ Adds support for displaying Tire related statistics in the Rails' log.
 
 Adds support for namespace all Index's of an Application
 
+### Dynamic Templates ###
+
+Adds support for ["dynamic templates"](http://www.elasticsearch.org/guide/reference/mapping/root-object-type/).
+
 -----
 
 [Karel Minarik](http://karmi.cz) and [contributors](http://github.com/karmi/tire-contrib/contributors)

--- a/lib/tire/dynamic_templates.rb
+++ b/lib/tire/dynamic_templates.rb
@@ -1,0 +1,57 @@
+# Dynamic Templates support in mapping DSL
+# ========================================
+#
+# This extension allows you to define the dynamic_templates property on the
+# root object type in elasticsearch. This allows you to e.g easily do
+# multi-fields on dynamic attributes. See the following URL for more info:
+#
+# http://www.elasticsearch.org/guide/reference/mapping/root-object-type/
+#
+# Usage:
+# ------
+#
+#     require 'tire/dynamic_templates'
+#     class MyModel # ...
+#       include Tire::Model::Search
+#       # ...
+#       mapping do
+#         dynamic_template "template_name",
+#           match: '*',
+#           match_mapping_type: 'string',
+#           mapping: {
+#             type: "multi_field",
+#             fields: {
+#               "{name}" => {
+#                 type: "{dynamic_type}",
+#                 index: "analyzed"
+#               },
+#               "org" => {
+#                 type: "{dynamic_type}",
+#                 index: "not_analyzed"
+#               }
+#             }
+#           }
+#       end
+#     end
+#
+
+module Tire
+  module Model
+    Search::ClassMethodsProxy::INTERFACE.concat [:dynamic_template, :dynamic_templates]
+    module Indexing
+      module ClassMethods
+        # Define a named dynamic template
+        # (see http://www.elasticsearch.org/guide/reference/mapping/root-object-type/)
+        def dynamic_template(name, options = {})
+          dynamic_templates << {name => options}
+          self
+        end
+        # Access existing dynamic templates
+        def dynamic_templates
+          @mapping_options ||= {}
+          @mapping_options[:dynamic_templates] ||= []
+        end
+      end
+    end
+  end
+end

--- a/test/dynamic_templates/mapping_test.rb
+++ b/test/dynamic_templates/mapping_test.rb
@@ -1,0 +1,53 @@
+require 'test_helper'
+
+require 'tire/dynamic_templates'
+
+include Mocha::API
+class MockModel
+  include Tire::Model::Search
+  def self.model_name
+    object = mock
+    object.stubs(:to_s).returns('dynamic_field_mapped_model')
+    object.stubs(:plural).returns('dynamic_field_mapped_models')
+    object
+  end
+  MAPPING = {
+    match: "*",
+    match_mapping_type: 'string',
+    mapping: {
+      type: "multi_field",
+      fields: {
+        "{name}" => {
+          type: "{dynamic_type}",
+          index: "analyzed"
+        },
+        "org" => {
+          type: "{dynamic_type}",
+          index: "not_analyzed"
+        }
+      }
+    }
+  }
+  mapping do
+    dynamic_template "foo", MockModel::MAPPING
+    dynamic_template "bar", MockModel::MAPPING
+  end
+end
+
+module Tire
+  module DynamicTemplates
+    class MappingTest < Test::Unit::TestCase
+      context "Dynamic templates defined" do
+        should "correctly set dynamic_templates" do
+          assert_equal MockModel.tire.mapping_to_hash, :dynamic_field_mapped_model => {
+            :dynamic_templates => [
+              {"foo" => MockModel::MAPPING},
+              {"bar" => MockModel::MAPPING}
+            ],
+            :properties        => {}
+          }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
I added some basic syntax around defining dynamic templates on the root object. As I was finishing up implementing this I realised you could actually just do this by adding an extra argument to the mapping call so maybe un-necessary, if so feel free to ignore.

Had a go at doing a basic test for it too, I'm not too familiar with this testing environment so let me know if there's anything I can change or make cleaner there.

Cheers
